### PR TITLE
List traversal now calls next_pos(data, nextpos) without passing querystr

### DIFF
--- a/hifiyaml/core.py
+++ b/hifiyaml/core.py
@@ -165,7 +165,7 @@ def get_start_pos(data, querystr="", stop_on_error=False, linestr=""):
                         nextpos = next_pos(data, nextpos)
                     cur = nextpos
                     if cur >= len(data):
-                        errmsg = f"WARNNING: out of the list index '{querystr}' "
+                        errmsg = f"WARNING: out of the list index '{querystr}' "
                         sys.stderr.write(f"{errmsg}\n")
                         if stop_on_error:
                             sys.exit(1)
@@ -176,7 +176,7 @@ def get_start_pos(data, querystr="", stop_on_error=False, linestr=""):
                     while dashpos < len(data) and data[dashpos].strip().startswith('#'):
                         dashpos += 1
                     if dashpos >= len(data) or "- " not in data[dashpos]:  # out of the list index
-                        errmsg = f"WARNNING: out of the list index '{querystr}' "
+                        errmsg = f"WARNING: out of the list index '{querystr}' "
                         sys.stderr.write(f"{errmsg}\n")
                         if stop_on_error:
                             sys.exit(1)

--- a/hifiyaml/core.py
+++ b/hifiyaml/core.py
@@ -89,12 +89,13 @@ def next_pos(data, pos, querystr=""):
     line1 = data[pos]
     nspace, spaces, line1 = strip_indentations(line1)
     if len(query_list) >= 2 and query_list[-2].isdigit() and not query_list[-1].isdigit():
-        # i.e, the ".../0/key" situation
+        # i.e, the ".../0/key" situation where key is on the same line as "- "
         # more complicated situations, such as a list of list (of list ...)
         # are suggested to be handled based on the first list block outside hifiyaml
-        line1 = line1[2:]  # assume "- " instead of "-   " or even more spaces
-        nspace += 2
-        spaces += "  "
+        if line1.startswith("- "):
+            line1 = line1[2:]  # assume "- " instead of "-   " or even more spaces
+            nspace += 2
+            spaces += "  "
 
     end = len(data)
     next_pos = None
@@ -161,7 +162,7 @@ def get_start_pos(data, querystr="", stop_on_error=False, linestr=""):
                     nextpos = i
                     knt = int(s)
                     for j in range(0, knt):
-                        nextpos = next_pos(data, nextpos, querystr)
+                        nextpos = next_pos(data, nextpos)
                     cur = nextpos
                     if cur >= len(data):
                         errmsg = f"WARNNING: out of the list index '{querystr}' "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hifiyaml"
-version = "0.1.9"
+version = "0.2.0"
 description = "High-fidelity WYSIWYG YAML parser and emitter that preserve exact formatting"
 readme = "README.md"
 authors = [

--- a/tests/ref/obsOperator.yaml
+++ b/tests/ref/obsOperator.yaml
@@ -1,0 +1,12 @@
+obs operator:
+    name: VertInterp
+    vertical coordinate: air_pressure
+    observation vertical coordinate: pressure
+    observation vertical coordinate group: MetaData
+    interpolation method: log-linear
+    #gsi geovals:
+    #  filename: "obsout/sfcship_tsen_geoval_2024052700.nc4"
+    #  levels_are_top_down: False
+    variables:
+    - name: airTemperature
+

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -15,6 +15,7 @@ operate.py demo.yaml dump "cost function/observations/observers/0/obs filters/3"
 operate.py demo.yaml dump "cost function/observations/observers/0/obs filters/4" > tmp/4.yaml
 operate.py demo.yaml dump "cost function/observations/observers/0/obs filters/5" > tmp/5.yaml
 operate.py demo.yaml dump "cost function/observations/observers/0/obs filters/6" > tmp/6.yaml
+operate.py demo.yaml dump "observations/observers/1/obs operator" > tmp/obsOperator.yaml
 
 operate.py demo.yaml modify "cost function/background error/components/0" bec_bump.yaml > tmp/new_bec.yaml
 operate.py demo.yaml modify "cost function/background error/components/0" bec_bump.yaml > tmp/new_bec.yaml

--- a/tests/test_hifiyaml.py
+++ b/tests/test_hifiyaml.py
@@ -870,6 +870,18 @@ class TestIntegrationDemo:
             assert isinstance(npos, int)
             assert npos > 641
 
+    def test_dump_observers_1_obs_operator(self, demo_data, capsys):
+        """Test that querying a key in a non-first list item works (the .../N/key fix)."""
+        block = hy.get(demo_data, "observations/observers/1/obs operator", do_dedent=True)
+        assert block[0] == "obs operator:"
+        assert any("VertInterp" in line for line in block)
+        assert any("name: airTemperature" in line for line in block)
+        # Should NOT include content from the next sibling key (linear obs operator)
+        assert not any("linear obs operator" in line for line in block)
+        # Should not trigger out-of-bounds warning during list traversal
+        captured = capsys.readouterr()
+        assert "out of the list index" not in captured.err
+
 
 # ============================================================
 # Tests: Serialization roundtrip


### PR DESCRIPTION
A bug was recently found that `./operate.py getkf.yaml dump "observations/observers/19/obs space"` could not get the correct YAML block.  It was because we should not pass querystr to `next_pos(...) ` for traverse a list and we only need to remove the leading `- ` when key is on the same line as `- ` for the `.../0/key` situation.